### PR TITLE
fix: removing a double trigger due to the visual toggle already being surrounded by a label

### DIFF
--- a/addon/components/x-toggle-switch/component.js
+++ b/addon/components/x-toggle-switch/component.js
@@ -13,14 +13,5 @@ export default Component.extend({
 
   themeClass: computed('theme', function() {
     return `x-toggle-${this.get('theme') || 'default'}`;
-  }),
-
-  click(e) {
-    const clickedElement = this.$(e.target);
-    const isIE = this.get('browserChecker.isExplorer');
-
-    if (isIE || clickedElement.is('input')) {
-      this.sendToggle(!this.get('value'));
-    }
-  }
+  })
 });


### PR DESCRIPTION
since the visual "toggle" already is a label, having a click handler was causing the `sendToggle` method to double fire. (one for the change event being triggered by clicking on the label, and one for the click on the div)

Could also remove the label, and leave the click event, and remove the "is input" stuff check.