### PR TITLE
removing the 'soon' to be depricated ember shim syntax

### DIFF
--- a/addon/components/x-toggle-label/component.js
+++ b/addon/components/x-toggle-label/component.js
@@ -1,6 +1,10 @@
-import Component from 'ember-component';
-import computed from 'ember-computed';
+import Ember from 'ember';
 import layout from './template';
+
+const {
+  Component,
+  computed,
+} = Ember;
 
 export default Component.extend({
   layout,

--- a/addon/components/x-toggle-switch/component.js
+++ b/addon/components/x-toggle-switch/component.js
@@ -1,6 +1,10 @@
-import Component from 'ember-component';
-import computed from 'ember-computed';
+import Ember from 'ember';
 import layout from './template';
+
+const {
+  Component,
+  computed,
+} = Ember;
 
 export default Component.extend({
   layout,

--- a/addon/components/x-toggle/component.js
+++ b/addon/components/x-toggle/component.js
@@ -1,6 +1,10 @@
-import Component from 'ember-component';
-import computed from 'ember-computed';
+import Ember from 'ember';
 import layout from './template';
+
+const {
+  Component,
+  computed,
+} = Ember;
 
 export default Component.extend({
   layout,


### PR DESCRIPTION
Reverting to the standard syntax with destructing. The new ember-cli-shims will be deprecating this old style of the shims when the latest beta version is released.

this closes #79