### PR TITLE
fix(deprecation): Fixed `canDispatchToEventManager` deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-gestures": "^0.4.7",
+    "ember-gestures": "^0.4.8",
     "ember-hammertime": "^1.2.4",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,9 +2566,9 @@ ember-factory-for-polyfill@^1.1.0:
   dependencies:
     ember-cli-version-checker "^1.2.0"
 
-ember-gestures@^0.4.7:
-  version "0.4.7"
-  resolved "https://registry.yarnpkg.com/ember-gestures/-/ember-gestures-0.4.7.tgz#c17559622377515ec996fd4c17abce51e026f106"
+ember-gestures@^0.4.8:
+  version "0.4.8"
+  resolved "https://registry.yarnpkg.com/ember-gestures/-/ember-gestures-0.4.8.tgz#b149e63dfbef21145adc856cd459460aad30dc37"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
Bumped `ember-gestures` to latest version in order to fix the following deprecation introduced in Ember 2.14 :

> DEPRECATION: `canDispatchToEventManager` has been deprecated in (EventDispatcher). [deprecation id: ember-views.event-dispatcher.canDispatchToEventManager]

https://www.emberjs.com/deprecations/v2.x/#toc_id-ember-views-event-dispatcher-candispatchtoeventmanager