### PR TITLE
Add stylelint to promote consistent styles

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-cli-qunit": "^4.0.0",
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
+    "ember-cli-stylelint": "^1.0.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
@@ -47,7 +48,8 @@
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.15.0-beta.1",
     "loader.js": "^4.2.3",
-    "standard-version": "^4.0.0"
+    "standard-version": "^4.0.0",
+    "stylelint-config-standard": "^17.0.0"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"

--- a/vendor/ember-toggle/base.css
+++ b/vendor/ember-toggle/base.css
@@ -3,32 +3,32 @@
 }
 
 .x-toggle,
-.x-toggle:after,
-.x-toggle:before,
+.x-toggle::after,
+.x-toggle::before,
 .x-toggle *,
-.x-toggle *:after,
-.x-toggle *:before,
+.x-toggle *::after,
+.x-toggle *::before,
 .x-toggle + label > .x-toggle-btn {
   -moz-box-sizing: border-box;
-       box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .x-toggle::-moz-selection,
-.x-toggle:after::-moz-selection,
-.x-toggle:before::-moz-selection,
+.x-toggle::after::-moz-selection,
+.x-toggle::before::-moz-selection,
 .x-toggle *::-moz-selection,
-.x-toggle *:after::-moz-selection,
-.x-toggle *:before::-moz-selection,
+.x-toggle *::after::-moz-selection,
+.x-toggle *::before::-moz-selection,
 .x-toggle + label > .x-toggle-btn::-moz-selection {
   background: none;
 }
 
 .x-toggle::selection,
-.x-toggle:after::selection,
-.x-toggle:before::selection,
+.x-toggle::after::selection,
+.x-toggle::before::selection,
 .x-toggle *::selection,
-.x-toggle *:after::selection,
-.x-toggle *:before::selection,
+.x-toggle *::after::selection,
+.x-toggle *::before::selection,
 .x-toggle + label > .x-toggle-btn::selection {
   background: none;
 }
@@ -39,9 +39,9 @@ label > .x-toggle-btn.x-toggle-disabled {
 
 label > .x-toggle-btn {
   -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   outline: 0;
   display: flex;
   flex-basis: 4em;
@@ -50,8 +50,8 @@ label > .x-toggle-btn {
   cursor: pointer;
 }
 
-label > .x-toggle-btn:after,
-label > .x-toggle-btn:before {
+label > .x-toggle-btn::after,
+label > .x-toggle-btn::before {
   position: relative;
   display: block;
   content: "";
@@ -59,15 +59,15 @@ label > .x-toggle-btn:before {
   height: 100%;
 }
 
-label > .x-toggle-btn:after {
+label > .x-toggle-btn::after {
   left: 0;
 }
 
-label > .x-toggle-btn:before {
+label > .x-toggle-btn::before {
   display: none;
 }
 
-.x-toggle:checked + label > .x-toggle-btn:after {
+.x-toggle:checked + label > .x-toggle-btn::after {
   left: 50%;
 }
 
@@ -85,26 +85,25 @@ label > .x-toggle-btn:before {
   padding: 0 0.35rem;
 }
 
-
 .x-toggle-component .toggle-text {
-	display: flex;
+  display: flex;
   cursor: pointer;
 }
 
 .x-toggle-container.small {
   width: 2.75rem;
-	font-size: 1.0rem;
+  font-size: 1rem;
   padding: 0 0.25rem;
 }
 
 .x-toggle-container.medium {
   width: 3.75rem;
-	font-size: 1.0rem;
+  font-size: 1rem;
 }
 
 .x-toggle-container.large {
   width: 5.7rem;
-	font-size: 1.2rem;
+  font-size: 1.2rem;
   padding: 0 0.5rem;
 }
 
@@ -114,16 +113,17 @@ label > .x-toggle-btn:before {
 }
 
 .x-toggle-container .toggle-text.toggle-prefix {
-	padding-right: 0.25rem;
+  padding-right: 0.25rem;
 }
 
 .x-toggle-container .toggle-text.toggle-postfix {
-	padding-left: 0.25rem;
+  padding-left: 0.25rem;
 }
 
 .x-toggle-component label.off-label {
   padding-right: 0.5rem;
 }
+
 .x-toggle-component label.on-label {
   padding-left: 0.5rem;
 }

--- a/vendor/ember-toggle/themes/default.css
+++ b/vendor/ember-toggle/themes/default.css
@@ -1,6 +1,6 @@
 label > .x-toggle-default.x-toggle-btn {
   padding: 0.16em 0.1em;
-  background-color: #E7E7E7;
+  background-color: #e7e7e7;
   border-radius: 0.2em;
   transition: background-color 0.2s;
 }
@@ -9,8 +9,8 @@ label > .x-toggle-default.x-toggle-btn {
   background-color: #797979;
 }
 
-label > .x-toggle-default.x-toggle-btn:after {
-  background-color: #FFFFFF;
+label > .x-toggle-default.x-toggle-btn::after {
+  background-color: #fff;
   transition: left 0.2s;
   border-radius: 0.2em;
 }

--- a/vendor/ember-toggle/themes/flat.css
+++ b/vendor/ember-toggle/themes/flat.css
@@ -1,27 +1,27 @@
 .x-toggle-flat.x-toggle-btn {
   padding: 2px;
-  -webkit-transition: all .2s ease;
-          transition: all .2s ease;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
   background: #fff;
   border: 4px solid #f2f2f2;
   border-radius: 2em;
 }
 
-.x-toggle-flat.x-toggle-btn:after {
-  -webkit-transition: all .2s ease;
-          transition: all .2s ease;
+.x-toggle-flat.x-toggle-btn::after {
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
   background: #f2f2f2;
   content: "";
   border-radius: 1em;
 }
 
-.x-toggle:checked + .label x-toggle-flat.x-toggle-btn {
-  border: 4px solid #7FC6A6;
+.x-toggle:checked + .label .x-toggle-flat.x-toggle-btn {
+  border: 4px solid #7fc6a6;
 }
 
-.x-toggle:checked + label .x-toggle-flat.x-toggle-btn:after {
+.x-toggle:checked + label .x-toggle-flat.x-toggle-btn::after {
   left: 50%;
-  background: #7FC6A6;
+  background: #7fc6a6;
 }
 
 .x-toggle-flat.small {

--- a/vendor/ember-toggle/themes/flip.css
+++ b/vendor/ember-toggle/themes/flip.css
@@ -1,63 +1,62 @@
 .x-toggle-flip.x-toggle-btn {
   padding: 2px;
-  -webkit-transition: all .2s ease;
-          transition: all .2s ease;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
   font-family: sans-serif;
   -webkit-perspective: 100px;
-          perspective: 100px;
+  perspective: 100px;
 }
 
-.x-toggle-flip.x-toggle-btn:after,
-.x-toggle-flip.x-toggle-btn:before {
+.x-toggle-flip.x-toggle-btn::after,
+.x-toggle-flip.x-toggle-btn::before {
   display: inline-block;
-  -webkit-transition: all .4s ease;
-          transition: all .4s ease;
+  -webkit-transition: all 0.4s ease;
+  transition: all 0.4s ease;
   width: 100%;
   text-align: center;
   position: absolute;
   line-height: 2em;
   font-weight: bold;
   color: #fff;
-  position: absolute;
   top: 0;
   left: 0;
   -webkit-backface-visibility: hidden;
-          backface-visibility: hidden;
+  backface-visibility: hidden;
   border-radius: 4px;
 }
 
-.x-toggle-flip.x-toggle-btn:after {
+.x-toggle-flip.x-toggle-btn::after {
   content: attr(data-tg-on);
-  background: #02C66F;
+  background: #02c66f;
   -webkit-transform: rotateY(-180deg);
-          transform: rotateY(-180deg);
+  transform: rotateY(-180deg);
 }
 
-.x-toggle-flip.x-toggle-btn:before {
-  background: #FF3A19;
+.x-toggle-flip.x-toggle-btn::before {
+  background: #ff3a19;
   content: attr(data-tg-off);
 }
 
-.x-toggle-flip.x-toggle-btn:active:before {
+.x-toggle-flip.x-toggle-btn:active::before {
   -webkit-transform: rotateY(-20deg);
-          transform: rotateY(-20deg);
+  transform: rotateY(-20deg);
 }
 
-.x-toggle:checked + label > .x-toggle-flip.x-toggle-btn:before {
+.x-toggle:checked + label > .x-toggle-flip.x-toggle-btn::before {
   -webkit-transform: rotateY(180deg);
-          transform: rotateY(180deg);
+  transform: rotateY(180deg);
 }
 
-.x-toggle:checked + label > .x-toggle-flip.x-toggle-btn:after {
+.x-toggle:checked + label > .x-toggle-flip.x-toggle-btn::after {
   -webkit-transform: rotateY(0);
-          transform: rotateY(0);
+  transform: rotateY(0);
   left: 0;
-  background: #7FC6A6;
+  background: #7fc6a6;
 }
 
-.x-toggle:checked + label > .x-toggle-flip.x-toggle-btn:active:after {
+.x-toggle:checked + label > .x-toggle-flip.x-toggle-btn:active::after {
   -webkit-transform: rotateY(20deg);
-          transform: rotateY(20deg);
+  transform: rotateY(20deg);
 }
 
 .x-toggle-flip.small {
@@ -65,8 +64,8 @@
   height: 1.6em;
 }
 
-.x-toggle-flip.small:before,
-.x-toggle-flip.small:after {
+.x-toggle-flip.small::before,
+.x-toggle-flip.small::after {
   line-height: 2.2em;
   font-size: 0.8em;
 }
@@ -77,8 +76,8 @@
   padding: 3px;
 }
 
-.x-toggle-flip.medium:before,
-.x-toggle-flip.medium:after {
+.x-toggle-flip.medium::before,
+.x-toggle-flip.medium::after {
   line-height: 2.3em;
 }
 
@@ -88,8 +87,8 @@
   padding: 4px;
 }
 
-.x-toggle-flip.large:before,
-.x-toggle-flip.large:after {
+.x-toggle-flip.large::before,
+.x-toggle-flip.large::after {
   line-height: 2.1em;
   font-size: 1.1em;
 }

--- a/vendor/ember-toggle/themes/ios.css
+++ b/vendor/ember-toggle/themes/ios.css
@@ -2,16 +2,16 @@
   background: #fbfbfb;
   border-radius: 2em;
   padding: 2px;
-  -webkit-transition: all .4s ease;
-          transition: all .4s ease;
+  -webkit-transition: all 0.4s ease;
+  transition: all 0.4s ease;
   border: 1px solid #e8eae9;
 }
 
-.x-toggle-ios.x-toggle-btn:after {
+.x-toggle-ios.x-toggle-btn::after {
   border-radius: 2em;
   background: #fbfbfb;
   -webkit-transition: left 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), padding 0.3s ease, margin 0.3s ease;
-          transition: left 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), padding 0.3s ease, margin 0.3s ease;
+  transition: left 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275), padding 0.3s ease, margin 0.3s ease;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1), 0 4px 0 rgba(0, 0, 0, 0.08);
 }
 
@@ -19,8 +19,8 @@
   box-shadow: inset 0 0 0 2em #e8eae9;
 }
 
-.x-toggle-ios.x-toggle-btn:active:after {
-  padding-right: .8em;
+.x-toggle-ios.x-toggle-btn:active::after {
+  padding-right: 0.8em;
 }
 
 .x-toggle:checked + label > .x-toggle-ios.x-toggle-btn {
@@ -31,8 +31,8 @@
   box-shadow: none;
 }
 
-.x-toggle:checked + label > .x-toggle-ios.x-toggle-btn:active:after {
-  margin-left: -.8em;
+.x-toggle:checked + label > .x-toggle-ios.x-toggle-btn:active::after {
+  margin-left: -0.8em;
 }
 
 .x-toggle-ios.small {

--- a/vendor/ember-toggle/themes/light.css
+++ b/vendor/ember-toggle/themes/light.css
@@ -2,19 +2,19 @@
   background: #f0f0f0;
   border-radius: 2em;
   padding: 2px;
-  -webkit-transition: all .4s ease;
-          transition: all .4s ease;
+  -webkit-transition: all 0.4s ease;
+  transition: all 0.4s ease;
 }
 
-.x-toggle-light.x-toggle-btn:after {
+.x-toggle-light.x-toggle-btn::after {
   border-radius: 50%;
   background: #fff;
-  -webkit-transition: all .2s ease;
-          transition: all .2s ease;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
 }
 
 .x-toggle:checked + label > .x-toggle-light.x-toggle-btn {
-  background: #9FD6AE;
+  background: #9fd6ae;
 }
 
 .x-toggle-light.small {

--- a/vendor/ember-toggle/themes/material.css
+++ b/vendor/ember-toggle/themes/material.css
@@ -3,48 +3,48 @@
 }
 
 /* Handle */
-.x-toggle-material.x-toggle-btn:after {
+.x-toggle-material.x-toggle-btn::after {
   border-radius: 2em;
-  background-color: #FAFAFA;
-  box-shadow: 0 3px 2px rgba(0, 0, 0, .1);
-  -webkit-transition: all .4s ease;
-          transition: all .4s ease;
+  background-color: #fafafa;
+  box-shadow: 0 3px 2px rgba(0, 0, 0, 0.1);
+  -webkit-transition: all 0.4s ease;
+  transition: all 0.4s ease;
 }
 
-.x-toggle:checked + label > .x-toggle-material.x-toggle-btn:after {
-  background-color: #7FC6A6;
+.x-toggle:checked + label > .x-toggle-material.x-toggle-btn::after {
+  background-color: #7fc6a6;
 }
 
 /* Background */
-.x-toggle-material.x-toggle-btn:before {
+.x-toggle-material.x-toggle-btn::before {
   position: absolute;
   display: block;
   height: 50%;
   width: 70%;
   left: 15%;
   content: '';
-  background-color: #000000;
-  opacity: .38;
+  background-color: #000;
+  opacity: 0.38;
   border-radius: 2em;
-  -webkit-transition: all .4s ease;
-          transition: all .4s ease;
+  -webkit-transition: all 0.4s ease;
+  transition: all 0.4s ease;
 }
 
-.x-toggle:checked + label > .x-toggle-material.x-toggle-btn:before {
-  background-color: #7FC6A6;
-  opacity: .5;
+.x-toggle:checked + label > .x-toggle-material.x-toggle-btn::before {
+  background-color: #7fc6a6;
+  opacity: 0.5;
 }
 
 /* Disabled */
-.x-toggle-material.x-toggle-btn.x-toggle-disabled:before,
-.x-toggle:checked + label > .x-toggle-material.x-toggle-btn.x-toggle-disabled:before {
-  background-color: #000000;
-  opacity: .12;
+.x-toggle-material.x-toggle-btn.x-toggle-disabled::before,
+.x-toggle:checked + label > .x-toggle-material.x-toggle-btn.x-toggle-disabled::before {
+  background-color: #000;
+  opacity: 0.12;
 }
 
-.x-toggle-material.x-toggle-btn.x-toggle-disabled:after,
-.x-toggle:checked + label > .x-toggle-material.x-toggle-btn.x-toggle-disabled:after {
-  background-color: #BDBDBD;
+.x-toggle-material.x-toggle-btn.x-toggle-disabled::after,
+.x-toggle:checked + label > .x-toggle-material.x-toggle-btn.x-toggle-disabled::after {
+  background-color: #bdbdbd;
 }
 
 /* Sizes */
@@ -54,8 +54,8 @@
   padding: 2px;
 }
 
-.x-toggle-material.small:before {
-  margin: .3em 0;
+.x-toggle-material.small::before {
+  margin: 0.3em 0;
 }
 
 .x-toggle-material.medium {
@@ -64,8 +64,8 @@
   padding: 3px;
 }
 
-.x-toggle-material.medium:before {
-  margin: .35em 0;
+.x-toggle-material.medium::before {
+  margin: 0.35em 0;
 }
 
 .x-toggle-material.large {
@@ -74,6 +74,6 @@
   padding: 4px;
 }
 
-.x-toggle-material.large:before {
-  margin: .4em 0;
+.x-toggle-material.large::before {
+  margin: 0.4em 0;
 }

--- a/vendor/ember-toggle/themes/skewed.css
+++ b/vendor/ember-toggle/themes/skewed.css
@@ -1,24 +1,24 @@
 .x-toggle-skewed.x-toggle-btn {
   overflow: hidden;
   -webkit-transform: skew(-10deg);
-      -ms-transform: skew(-10deg);
-          transform: skew(-10deg);
+  -ms-transform: skew(-10deg);
+  transform: skew(-10deg);
   -webkit-backface-visibility: hidden;
-          backface-visibility: hidden;
-  -webkit-transition: all .2s ease;
-          transition: all .2s ease;
+  backface-visibility: hidden;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
   font-family: sans-serif;
   background: #888;
 }
 
-.x-toggle-skewed.x-toggle-btn:after,
-.x-toggle-skewed.x-toggle-btn:before {
+.x-toggle-skewed.x-toggle-btn::after,
+.x-toggle-skewed.x-toggle-btn::before {
   -webkit-transform: skew(10deg);
-      -ms-transform: skew(10deg);
-          transform: skew(10deg);
+  -ms-transform: skew(10deg);
+  transform: skew(10deg);
   display: inline-block;
-  -webkit-transition: all .2s ease;
-          transition: all .2s ease;
+  -webkit-transition: all 0.2s ease;
+  transition: all 0.2s ease;
   width: 100%;
   text-align: center;
   position: absolute;
@@ -28,12 +28,12 @@
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
 }
 
-.x-toggle-skewed.x-toggle-btn:after {
+.x-toggle-skewed.x-toggle-btn::after {
   left: -110%;
   content: attr(data-tg-on);
 }
 
-.x-toggle-skewed.x-toggle-btn:before {
+.x-toggle-skewed.x-toggle-btn::before {
   left: 0;
   content: attr(data-tg-off);
 }
@@ -46,11 +46,11 @@
   background: #86d993;
 }
 
-.x-toggle:checked + label > .x-toggle-skewed.x-toggle-btn:before {
+.x-toggle:checked + label > .x-toggle-skewed.x-toggle-btn::before {
   left: 100%;
 }
 
-.x-toggle:checked + label > .x-toggle-skewed.x-toggle-btn:after {
+.x-toggle:checked + label > .x-toggle-skewed.x-toggle-btn::after {
   left: 0;
 }
 
@@ -59,8 +59,8 @@
   height: 1.6em;
 }
 
-.x-toggle-skewed.small:before,
-.x-toggle-skewed.small:after {
+.x-toggle-skewed.small::before,
+.x-toggle-skewed.small::after {
   line-height: 2.2em;
   font-size: 0.8em;
 }
@@ -71,8 +71,8 @@
   padding: 3px;
 }
 
-.x-toggle-skewed.medium:before,
-.x-toggle-skewed.medium:after {
+.x-toggle-skewed.medium::before,
+.x-toggle-skewed.medium::after {
   line-height: 1.9em;
 }
 
@@ -82,8 +82,8 @@
   padding: 4px;
 }
 
-.x-toggle-skewed.large:before,
-.x-toggle-skewed.large:after {
+.x-toggle-skewed.large::before,
+.x-toggle-skewed.large::after {
   line-height: 1.7em;
   font-size: 1.1em;
 }


### PR DESCRIPTION
Introduces Stylelint to the project according to issue #103.

It was installed by simply running `ember install ember-cli-stylelint`.
The lastest version of `ember-cli-stylelint` also automatically adds `stylelint-config-standard` to the package.json and sets stylelint to use it as the default ruleset.

CSS files in the project have been fixed to comply with the new rules.