### PR TITLE
Update ember-gestures version to 1.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-gestures": "^0.4.8",
+    "ember-gestures": "^1.1.0",
     "ember-hammertime": "^1.4.1",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },


### PR DESCRIPTION
Updated ember-gestures version to 1.1.0 to resolve ember-cli-babel deprecation warning.