### PR TITLE
Make versions of ember-gestures less than 1.1.1 unacceptable

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
     "ember-cli-htmlbars": "^3.0.0",
-    "ember-gestures": "^1.1.0",
+    "ember-gestures": "^1.1.1",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
ember-gestures < 1.1.1 have a memory leak that can cause Chrome to run out memory when running tests.