### PR TITLE
Fix `ember-component-is-visible` deprecation (3.15)

### DIFF
--- a/addon/components/x-toggle-label/component.js
+++ b/addon/components/x-toggle-label/component.js
@@ -10,8 +10,7 @@ export default Component.extend({
   classNames: ['toggle-text', 'toggle-prefix'],
   classNameBindings: ['labelType'],
   for: readOnly('switchId'),
-  isVisible: readOnly('show'),
-  
+
   labelType: computed('type', function() {
     let type = this.get('type');
     

--- a/addon/components/x-toggle-label/template.hbs
+++ b/addon/components/x-toggle-label/template.hbs
@@ -1,5 +1,7 @@
-{{#if hasBlock}}
-  {{yield this.label}}
-{{else}}
-  {{this.label}}
+{{#if this.show}}
+  {{#if hasBlock}}
+    {{yield this.label}}
+  {{else}}
+    {{this.label}}
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
Address [this deprecation](https://deprecations.emberjs.com/v3.x/#toc_ember-component-is-visible). All tests are passing but it's possible this has somehow subtly altered behavior.