### PR TITLE
docs: use yarn instead of npm in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,12 @@
 
 - `git clone <repository-url>`
 - `cd ember-toggle`
-- `npm install`
+- `yarn install` or `yarn`
 
 ## Linting
 
-* `npm run lint`
-* `npm run lint:fix`
+* `yarn lint`
+* `yarn lint:fix`
 
 ## Running tests
 


### PR DESCRIPTION
Simple correction in the `CONTRIBUTING.md` file.