### PR TITLE
fix: only use default values if null or undefined is passed

### DIFF
--- a/addon/components/x-toggle.js
+++ b/addon/components/x-toggle.js
@@ -10,8 +10,8 @@ function configValue(configName, defaultValue) {
     return {
       get() {
         return (
-          this.args[name] ||
-          (configName && this.config?.[configName]) ||
+          this.args[name] ??
+          (configName && this.config?.[configName]) ??
           defaultValue
         );
       },


### PR DESCRIPTION
If we use the `||` operator it will use the default value if a falsy (for example `""` or `0`) value is passed as argument or config. This will result in e.g `@offLabel=""` rendering a label "Off" when we actually wanted it to not render anything. This is a regression from previous versions.